### PR TITLE
Change airtel and mtn service ports to 443

### DIFF
--- a/helm/ph-ee-engine/templates/connector-airtel.yaml
+++ b/helm/ph-ee-engine/templates/connector-airtel.yaml
@@ -128,7 +128,7 @@ spec:
       protocol: TCP
       targetPort: 5000
     - name: tomcat
-      port: 82
+      port: 443
       protocol: TCP
       targetPort: 8080
   selector:

--- a/helm/ph-ee-engine/templates/connector-mtn-rw.yaml
+++ b/helm/ph-ee-engine/templates/connector-mtn-rw.yaml
@@ -118,7 +118,7 @@ spec:
       protocol: TCP
       targetPort: 5000
     - name: tomcat
-      port: 82
+      port: 443
       protocol: TCP
       targetPort: 8080
   selector:


### PR DESCRIPTION
## Description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated service port for "tomcat" from 82 to 443 in both Airtel and MTN Rwanda connectors to standardize access via HTTPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->