### PR TITLE
Add envs for channel callback url

### DIFF
--- a/helm/ph-ee-engine/templates/connector-channel.yaml
+++ b/helm/ph-ee-engine/templates/connector-channel.yaml
@@ -70,6 +70,10 @@ spec:
               value: "{{ .Values.channel.operations.url }}"
             - name: "AMS"
               value: "{{ .Values.channel.AMS  }}"
+            - name: "CALLBACK_URL_RESTRICT"
+              value: "{{ .Values.channel.callbackUrl.restrict }}"
+            - name: "CALLBACK_URL_ALLOWED_DOMAINS"
+              value: "{{ .Values.channel.callbackUrl.allowedDomains }}"
             - name: "PAYMENTSCHEMES"
               value: {{ .Values.channel.paymentSchemes | toJson | quote }}
             - name: "LOGGING_PATTERN_CONSOLE"

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -299,6 +299,9 @@ channel:
     tnm: mpamba
     nbs: nbs
     bancobu: bancobu
+  callbackUrl:
+    restrict: false
+    allowedDomains: "oneacrefund.org"
 
 operations:
   enabled: true


### PR DESCRIPTION
## Description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new configuration options to restrict callback URLs and specify allowed domains for callbacks in the channel component. These can now be set via Helm values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->