### PR TITLE
feat/CP-3662: Add keycloak env variables in PH Ops App

### DIFF
--- a/helm/ph-ee-engine/templates/operations-app.yaml
+++ b/helm/ph-ee-engine/templates/operations-app.yaml
@@ -63,6 +63,14 @@ spec:
               value: "{{ .Values.operations_app.LOGGING_LEVEL_ROOT }}"
             - name: "LOGGING_PATTERN_CONSOLE"
               value: "{{ .Values.operations_app.LOGGING_PATTERN_CONSOLE }}"
+            - name: "KEYCLOAK_BASE_URL"
+              value: "{{ .Values.operations_app.keycloak.base_url }}"
+            - name: "KEYCLOAK_CLIENT_ID"
+              value: "{{ .Values.operations_app.keycloak.client_id }}"
+            - name: "KEYCLOAK_REALM"
+              value: "{{ .Values.operations_app.keycloak.realm }}"
+            - name: "PH_OPERATIONS_APP_SWAGGER_REDIRECT_URL"
+              value: "{{ .Values.operations_app.keycloak.ops_app_swagger_redirection_url }}"
           volumeMounts:
             - name: ph-ee-config
               mountPath: "/config"

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -394,6 +394,11 @@ operations_app:
   hostname: ""
   tenants: "oaf"
   token_client_channel_secret: ""
+  keycloak:
+    base_url: "$(KEYCLOAK_BASE_URL)"
+    client_id: "$(KEYCLOAK_CLIENT_ID)"
+    realm: "$(KEYCLOAK_REALM)"
+    ops_app_swagger_redirection_url: "$(PH_OPERATIONS_APP_SWAGGER_REDIRECT_URL)"
   datasource:
     username: "mifos"
     password: "password"


### PR DESCRIPTION
## Description

* Add keycloak env variables in PH Ops App

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable Keycloak authentication settings for the Operations App (base URL, realm, client ID) to enable SSO.
  - Introduced a configurable redirect URL for the Operations App API docs (Swagger).

- Chores
  - Updated Helm values and templates to surface new authentication and Swagger redirection settings via environment variables for easier deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->