### PR TITLE
feat(CP-3783): Ops web - Add Keycloak env variables

### DIFF
--- a/helm/ph-ee-engine/templates/operations-web.yaml
+++ b/helm/ph-ee-engine/templates/operations-web.yaml
@@ -33,6 +33,17 @@ spec:
             requests:
               memory: "{{ .Values.operations_web.requests.memory }}"
               cpu: "{{ .Values.operations_web.requests.cpu }}"
+          env:
+            - name: "KEYCLOAK_BASE_URL"
+              value: "{{ .Values.operations_web.oauth.keycloak.base_url }}"
+            - name: "KEYCLOAK_CLIENT_ID"
+              value: "{{ .Values.operations_web.oauth.keycloak.client_id }}"
+            - name: "KEYCLOAK_REALM"
+              value: "{{ .Values.operations_web.oauth.keycloak.realm }}"
+            - name: "KEYCLOAK_TOKEN_URL"
+              value: "{{ .Values.operations_web.oauth.keycloak.token_url }}"
+            - name: "OPERATIONS_WEB_HOME_URL"
+              value: "{{ .Values.operations_web.oauth.keycloak.redirect_url }}"
           volumeMounts:
             - name: ph-ee-operations-web-config
               mountPath: "/usr/share/nginx/html/assets/configuration.properties"

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -430,6 +430,14 @@ operations_web:
   imagePullPolicy: IfNotPresent
   hostname: ""
   webhost: ""
+  oauth:
+    enabled: true
+    keycloak:
+      base_url: "$(KEYCLOAK_BASE_URL)"
+      client_id: "$(KEYCLOAK_CLIENT_ID)"
+      realm: "$(KEYCLOAK_REALM)"
+      token_url: "$(KEYCLOAK_TOKEN_URL)"
+      redirect_url: "$(OPERATIONS_WEB_HOME_URL)"
   limits:
     memory: "512M"
     cpu: "500m"


### PR DESCRIPTION
## Description

* Add env variables for Keycloak in Ops web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds OAuth 2.0/Keycloak authentication support for Operations Web, including configurable base URL, realm, client ID, token URL, and redirect/home URL.
  - Enables OAuth by default with values-driven configuration for easier setup across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->