### PR TITLE
Updated airtel connector variables

### DIFF
--- a/helm/ph-ee-engine/templates/connector-airtel.yaml
+++ b/helm/ph-ee-engine/templates/connector-airtel.yaml
@@ -90,6 +90,12 @@ spec:
               value: "{{ .Values.airtel_connector.api.collection_endpoint }}"
             - name: "AIRTEL_API_STATUS-ENDPOINT"
               value: "{{ .Values.airtel_connector.api.status_endpoint }}"
+            - name: "AIRTEL_CREDENTIALS_RWANDA_BASE-URL"
+              value: "{{ .Values.airtel_connector.credentials.base_url }}"
+            - name: "AIRTEL_CREDENTIALS_ZAMBIA_BASE-URL"
+              value: "{{ .Values.airtel_connector.credentials.zambia.base_url }}"
+            - name: "AIRTEL_CREDENTIALS_MALAWI_BASE-URL"
+              value: "{{ .Values.airtel_connector.credentials.malawi.base_url }}"
             - name: "AIRTEL_CREDENTIALS_RWANDA_CLIENTID"
               valueFrom:
                 secretKeyRef:
@@ -110,6 +116,16 @@ spec:
                 secretKeyRef:
                   name: "airtel-secret"
                   key: "zambia-client-secret"
+            - name: "AIRTEL_CREDENTIALS_MALAWI_CLIENTID"
+              valueFrom:
+                secretKeyRef:
+                  name: "airtel-secret"
+                  key: "malawi-client-id"
+            - name: "AIRTEL_CREDENTIALS_MALAWI_CLIENTSECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: "airtel-secret"
+                  key: "malawi-client-secret"
             - name: "AIRTEL_CREDENTIALS_RWANDA_GRANT-TYPE"
               value: "{{ .Values.airtel_connector.credentials.grant_type }}"
             - name: "AIRTEL_CREDENTIALS_ZAMBIA_GRANT-TYPE"
@@ -146,6 +162,8 @@ data:
   client-secret: {{ .Values.airtel_connector.credentials.client_secret | b64enc }}
   zambia-client-id: {{ .Values.airtel_connector.credentials.zambia_client_id | b64enc}}
   zambia-client-secret: {{ .Values.airtel_connector.credentials.zambia_client_secret | b64enc }}
+  malawi-client-id: {{ .Values.airtel_connector.credentials.malawi_client_id | b64enc}}
+  malawi-client-secret: {{ .Values.airtel_connector.credentials.malawi_client_secret | b64enc }}
 
 --- 
 apiVersion: v1

--- a/helm/ph-ee-engine/templates/connector-airtel.yaml
+++ b/helm/ph-ee-engine/templates/connector-airtel.yaml
@@ -93,9 +93,9 @@ spec:
             - name: "AIRTEL_CREDENTIALS_RWANDA_BASE-URL"
               value: "{{ .Values.airtel_connector.credentials.base_url }}"
             - name: "AIRTEL_CREDENTIALS_ZAMBIA_BASE-URL"
-              value: "{{ .Values.airtel_connector.credentials.zambia.base_url }}"
+              value: "{{ .Values.airtel_connector.credentials.zambia_base_url }}"
             - name: "AIRTEL_CREDENTIALS_MALAWI_BASE-URL"
-              value: "{{ .Values.airtel_connector.credentials.malawi.base_url }}"
+              value: "{{ .Values.airtel_connector.credentials.malawi_base_url }}"
             - name: "AIRTEL_CREDENTIALS_RWANDA_CLIENTID"
               valueFrom:
                 secretKeyRef:

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -1159,15 +1159,19 @@ airtel_connector:
     memory: "512M"
     cpu: "100m"
   api:
-    base_url: "https://openapiuat.airtel.africa"
     auth_endpoint: "/auth/oauth2/token"
     collection_endpoint: "/merchant/v1/payments/"
     status_endpoint: "/standard/v1/payments"
   credentials:
     client_id: "abc"
     client_secret: "xyz"
+    base_url: "https://openapiuat.airtel.co.rw"
     zambia_client_id: "abc"
     zambia_client_secret: "xyz"
+    zambia_base_url: "https://openapiuat.airtel.co.zm"
+    malawi_client_id: "abc"
+    malawi_client_secret: "xyz"
+    malawi_base_url: "https://openapiuat.airtel.mw"
     grant_type: "client_credentials"
   max_retry_count: 3
   timeout: 6000

--- a/helm/ph-ee-engine/values.yaml
+++ b/helm/ph-ee-engine/values.yaml
@@ -1159,6 +1159,7 @@ airtel_connector:
     memory: "512M"
     cpu: "100m"
   api:
+    base_url: "https://openapiuat.airtel.africa"
     auth_endpoint: "/auth/oauth2/token"
     collection_endpoint: "/merchant/v1/payments/"
     status_endpoint: "/standard/v1/payments"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Malawi support to the Airtel connector with region-specific OAuth credentials.
  * Reworked Airtel connector credential configuration to support country-specific endpoints and authentication parameters for Malawi and Zambia, enabling separate base URLs and client credentials per country.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->